### PR TITLE
Roll Dice via API call and show totals on front end

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -71,3 +71,157 @@ button:disabled {
   font-style: italic;
   margin-top: 2rem;
 }
+
+/* Dice Rolling Form Styles */
+.dice-inputs {
+  margin: 1rem 0;
+}
+
+.dice-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 5px;
+}
+
+.dice-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #e0e0e0;
+  font-weight: bold;
+}
+
+.dice-row select,
+.dice-row input {
+  padding: 0.5rem;
+  border: 1px solid #ffd700;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  color: #e0e0e0;
+  font-size: 1rem;
+}
+
+.dice-row select:focus,
+.dice-row input:focus {
+  outline: none;
+  border-color: #ff6b6b;
+  box-shadow: 0 0 5px rgba(255, 107, 107, 0.3);
+}
+
+.remove-btn {
+  background: #ff4444;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.3s ease;
+}
+
+.remove-btn:hover {
+  background: #ff6666;
+}
+
+.dice-actions {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+  justify-content: center;
+}
+
+.add-btn {
+  background: linear-gradient(45deg, #4CAF50, #45a049);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+  color: white;
+  transition: all 0.3s ease;
+}
+
+.add-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(76, 175, 80, 0.4);
+}
+
+.roll-btn {
+  background: linear-gradient(45deg, #ff6b6b, #ffd700);
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+  color: #1a1a2e;
+  font-size: 1.1rem;
+  transition: all 0.3s ease;
+}
+
+.roll-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(255, 215, 0, 0.4);
+}
+
+.roll-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dice-results {
+  margin-top: 2rem;
+  padding: 1rem;
+  background: rgba(0, 255, 0, 0.1);
+  border: 1px solid #00ff00;
+  border-radius: 8px;
+}
+
+.dice-results h3 {
+  color: #00ff00;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.result-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+}
+
+.result-row strong {
+  color: #ffd700;
+  min-width: 80px;
+}
+
+.rolls {
+  color: #e0e0e0;
+  font-family: monospace;
+}
+
+.total {
+  color: #00ff00;
+  font-weight: bold;
+  margin-left: auto;
+}
+
+.grand-total {
+  text-align: center;
+  margin-top: 1rem;
+  padding: 1rem;
+  background: rgba(255, 215, 0, 0.2);
+  border: 2px solid #ffd700;
+  border-radius: 8px;
+  font-size: 1.2rem;
+}
+
+.grand-total strong {
+  color: #ffd700;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,30 @@
 import { useState } from 'react'
 import './App.css'
 
+interface DiceSpec {
+  sides: number
+  count: number
+}
+
+interface DiceResult {
+  sides: number
+  count: number
+  rolls: number[]
+  total: number
+}
+
+interface DiceRollResponse {
+  diceResults: DiceResult[]
+  total: number
+}
+
 function App() {
   const [message, setMessage] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
+  const [diceRolls, setDiceRolls] = useState<DiceRollResponse | null>(null)
+  const [diceInput, setDiceInput] = useState<DiceSpec[]>([
+    { sides: 6, count: 1 }
+  ])
 
   const fetchHello = async () => {
     setLoading(true)
@@ -16,6 +37,47 @@ function App() {
     } finally {
       setLoading(false)
     }
+  }
+
+  const rollDice = async () => {
+    setLoading(true)
+    setMessage('') // Clear any previous messages
+    try {
+      const response = await fetch('http://localhost:8080/api/roll', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ dice: diceInput }),
+      })
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      
+      const result: DiceRollResponse = await response.json()
+      console.log('Received response:', result) // Debug log
+      setDiceRolls(result)
+    } catch (error) {
+      setMessage('Error rolling dice: ' + error)
+      console.error('Dice roll error:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const addDice = () => {
+    setDiceInput([...diceInput, { sides: 6, count: 1 }])
+  }
+
+  const removeDice = (index: number) => {
+    setDiceInput(diceInput.filter((_, i) => i !== index))
+  }
+
+  const updateDice = (index: number, field: 'sides' | 'count', value: number) => {
+    const updated = [...diceInput]
+    updated[index] = { ...updated[index], [field]: value }
+    setDiceInput(updated)
   }
 
   return (
@@ -31,6 +93,74 @@ function App() {
           <div className="message">
             <h3>Backend Response:</h3>
             <p>{message}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="card">
+        <h2>🎲 Roll Dice</h2>
+        
+        <div className="dice-inputs">
+          {diceInput.map((dice, index) => (
+            <div key={index} className="dice-row">
+              <label>
+                Sides:
+                <select 
+                  value={dice.sides} 
+                  onChange={(e) => updateDice(index, 'sides', parseInt(e.target.value))}
+                >
+                  <option value={3}>d3</option>
+                  <option value={4}>d4</option>
+                  <option value={6}>d6</option>
+                  <option value={8}>d8</option>
+                  <option value={10}>d10</option>
+                  <option value={12}>d12</option>
+                  <option value={20}>d20</option>
+                  <option value={100}>d100</option>
+                </select>
+              </label>
+              
+              <label>
+                Count:
+                <input 
+                  type="number" 
+                  min="1" 
+                  value={dice.count} 
+                  onChange={(e) => updateDice(index, 'count', parseInt(e.target.value) || 1)}
+                />
+              </label>
+              
+              {diceInput.length > 1 && (
+                <button onClick={() => removeDice(index)} className="remove-btn">
+                  Remove
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+        
+        <div className="dice-actions">
+          <button onClick={addDice} className="add-btn">
+            + Add More Dice
+          </button>
+          <button onClick={rollDice} disabled={loading} className="roll-btn">
+            {loading ? 'Rolling...' : '🎲 Roll Dice'}
+          </button>
+        </div>
+        
+        {diceRolls && (
+          <div className="dice-results">
+            <h3>Results:</h3>
+            {diceRolls.diceResults.map((result, index) => (
+              <div key={index} className="result-row">
+                <strong>{result.count}d{result.sides}:</strong> 
+                <span className="rolls">[{result.rolls.join(', ')}]</span>
+                <span className="total">= {result.total}</span>
+              </div>
+            ))}
+            <div className="grand-total">
+              <strong>Total: {diceRolls.total}</strong>
+            </div>
           </div>
         )}
       </div>

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/controllers/DiceController.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/controllers/DiceController.kt
@@ -2,10 +2,16 @@ package com.aidnd.game_engine.controllers
 
 import org.springframework.web.bind.annotation.*
 
+import com.aidnd.game_engine.dto.DiceRollRequest
+import com.aidnd.game_engine.dto.DiceRollResponse
+import com.aidnd.game_engine.services.DiceService
+
 @RestController
 @RequestMapping("/api")
 @CrossOrigin(origins = ["http://localhost:3000"])
-class DiceController {
+class DiceController(
+    private val diceService: DiceService
+) {
     
     @GetMapping("/hello")
     fun hello(): String {
@@ -20,5 +26,10 @@ class DiceController {
             "result" to result,
             "message" to "Rolled a ${sides}-sided die"
         )
+    }
+    
+    @PostMapping("/roll")
+    fun rollMultipleDice(@RequestBody request: DiceRollRequest): DiceRollResponse {
+        return diceService.rollDice(request)
     }
 }

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/dto/DiceRollRequest.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/dto/DiceRollRequest.kt
@@ -1,0 +1,7 @@
+package com.aidnd.game_engine.dto
+
+import com.aidnd.game_engine.models.DiceSpec
+
+data class DiceRollRequest(
+    val dice: List<DiceSpec>
+)

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/dto/DiceRollResponse.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/dto/DiceRollResponse.kt
@@ -1,0 +1,8 @@
+package com.aidnd.game_engine.dto
+
+import com.aidnd.game_engine.models.DiceResult
+
+data class DiceRollResponse(
+    val diceResults: List<DiceResult>,
+    val total: Int
+)

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/models/DiceResult.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/models/DiceResult.kt
@@ -1,0 +1,8 @@
+package com.aidnd.game_engine.models
+
+data class DiceResult(
+    val sides: Int,
+    val count: Int,
+    val rolls: List<Int>,
+    val total: Int
+)

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/models/DiceSpec.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/models/DiceSpec.kt
@@ -1,0 +1,15 @@
+package com.aidnd.game_engine.models
+
+data class DiceSpec(
+    val sides: Int,
+    val count: Int
+) {
+    init {
+        require(sides in DiceType.validSides) {
+            "Invalid dice type: $sides. Valid types: ${DiceType.validSides}"
+        }
+        require(count > 0) {
+            "Dice count must be positive, got: $count"
+        }
+    }
+}

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/models/DiceType.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/models/DiceType.kt
@@ -1,0 +1,16 @@
+package com.aidnd.game_engine.models
+
+enum class DiceType(val sides: Int) {
+    d3(3),
+    d4(4),
+    d6(6),
+    d8(8),
+    d10(10),
+    d12(12),
+    d20(20),
+    d100(100);
+    
+    companion object {
+        val validSides = values().map { it.sides }
+    }
+}

--- a/game-engine/src/main/kotlin/com/aidnd/game_engine/services/DiceService.kt
+++ b/game-engine/src/main/kotlin/com/aidnd/game_engine/services/DiceService.kt
@@ -1,0 +1,28 @@
+package com.aidnd.game_engine.services
+
+import com.aidnd.game_engine.dto.DiceRollRequest
+import com.aidnd.game_engine.models.DiceSpec
+
+import com.aidnd.game_engine.dto.DiceRollResponse
+import com.aidnd.game_engine.models.DiceResult
+import org.springframework.stereotype.Service
+
+@Service
+class DiceService {
+    fun rollDice(request: DiceRollRequest): DiceRollResponse {
+        val diceResults = request.dice.map { diceSpec ->
+            val rolls = (1..diceSpec.count).map { (1..diceSpec.sides).random() }
+            DiceResult(
+                sides = diceSpec.sides,
+                count = diceSpec.count,
+                rolls = rolls,
+                total = rolls.sum()
+            )
+        }
+        
+        return DiceRollResponse(
+            diceResults = diceResults,
+            total = diceResults.sumOf { it.total }
+        )
+    }
+}

--- a/game-engine/src/test/kotlin/com/aidnd/game_engine/models/DiceSpecTest.kt
+++ b/game-engine/src/test/kotlin/com/aidnd/game_engine/models/DiceSpecTest.kt
@@ -1,0 +1,43 @@
+package com.aidnd.game_engine.models
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DiceSpecTest {
+
+    @Test
+    fun `should create valid dice spec with standard dice`() {
+        DiceType.values().forEach { diceType ->
+            val diceSpec = DiceSpec(sides = diceType.sides, count = 1)
+            assertEquals(diceType.sides, diceSpec.sides)
+            assertEquals(1, diceSpec.count)
+        }
+    }
+
+    @Test
+    fun `should throw exception for invalid dice sides`() {
+        val invalidSides = listOf(1, 2, 5, 7, 9, 11, 13, 99, 101)
+        
+        invalidSides.forEach { sides ->
+            assertThrows<IllegalArgumentException> {
+                DiceSpec(sides = sides, count = 1)
+            }
+        }
+    }
+
+    @Test
+    fun `should throw exception for zero count`() {
+        assertThrows<IllegalArgumentException> {
+            DiceSpec(sides = 6, count = 0)
+        }
+    }
+
+    @Test
+    fun `should throw exception for negative count`() {
+        assertThrows<IllegalArgumentException> {
+            DiceSpec(sides = 6, count = -1)
+        }
+    }
+}


### PR DESCRIPTION
Add `POST` endpoint to DiceController for rolling n number of each type of valid dice in DND. Performs rolls and returns structured response so each die's value and the total are returned.

Updates the App component with a simple form to perform this request and show response, but this is just gen AI and can be thrown out later